### PR TITLE
Add high level scenario for Admin publishing an auction

### DIFF
--- a/app/view_models/admin/edit_auction_view_model.rb
+++ b/app/view_models/admin/edit_auction_view_model.rb
@@ -45,11 +45,6 @@ class Admin::EditAuctionViewModel < Admin::BaseViewModel
     end
   end
 
-  def publishable?
-    closed? || auction.purchase_card == 'other' ||
-      auction.c2_status == 'approved'
-  end
-
   def customer_options
     ([auction.customer] + Customer.sorted).uniq.compact
   end
@@ -92,5 +87,10 @@ class Admin::EditAuctionViewModel < Admin::BaseViewModel
 
   def closed?
     AuctionStatus.new(auction).over?
+  end
+
+  def publishable?
+    closed? || auction.purchase_card == 'other' ||
+      auction.c2_status == 'approved'
   end
 end

--- a/features/admin_publishes_auction.feature
+++ b/features/admin_publishes_auction.feature
@@ -27,3 +27,20 @@ Feature: Admin publishes auction in the admin panel
     And the auction is for a different purchase card
     When I visit the admin form for that auction
     Then I should be able to set the auction to published
+
+  @javascript
+  Scenario: Admin creates and publishes auction with other purchase card
+    Given I am an administrator
+    And there is a client account to bill to
+    And there is a skill in the system
+    When I sign in
+    And I visit the auctions admin page
+    When I click on the add auction link
+    And I fill auction form with choosing "other" purchase card
+    Then I should see that the auction type is sealed bid
+    And I click to create an auction
+    Then I should see the auction's title
+
+    When I click on the auction's title
+    Then I should see the start time I set for the auction
+    And I should see the end time I set for the auction

--- a/features/step_definitions/admin_auction_form_steps.rb
+++ b/features/step_definitions/admin_auction_form_steps.rb
@@ -35,6 +35,51 @@ Then(/^I set the auction type to be reverse$/) do
   select("reverse", from: "auction_type")
 end
 
+When(/^I fill auction form with choosing "([^"]*)" purchase card$/) do |purchase_card|
+  @title = 'This is the form-edited title'
+  fill_in("auction_title", with: @title)
+
+  @description = 'and the admin related stuff'
+  fill_in("auction_description", with: @description)
+
+  @repo = 'https://github.com/18F/calc'
+  fill_in('auction_github_repo', with: @repo)
+
+  @summary = 'The Summary!'
+  fill_in('auction_summary', with: @summary)
+
+  @issue_url = 'https://github.com/18F/calc/issues/255'
+  fill_in('auction_issue_url', with: @issue_url)
+
+  @start_day = DcTimePresenter.convert(3.days.from_now)
+  fill_in "auction_started_at", with: @start_day.strftime('%Y-%m-%d')
+  select('11', from: 'auction_started_at_1i')
+  select('30', from: 'auction_started_at_2i')
+  select('AM', from: 'auction_started_at_3i')
+  @start_time = DcTimePresenter.time_zone.parse("#{@start_day.strftime('%Y-%m-%d')} 11:30 AM")
+
+  @end_day = DcTimePresenter.convert(3.days.from_now)
+  fill_in "auction_ended_at", with: @end_day.strftime('%Y-%m-%d')
+  select('4', from: 'auction_ended_at_1i')
+  select('45', from: 'auction_ended_at_2i')
+  select('PM', from: 'auction_ended_at_3i')
+  @end_time = DcTimePresenter.time_zone.parse("#{@start_day.strftime('%Y-%m-%d')} 4:45 PM")
+
+  @time_in_days = 3
+  @deadline_day = DcTimePresenter.convert(@time_in_days.business_days.from_now)
+  select("6", from: "auction_due_in_days")
+
+  select("published", from: "auction_published")
+
+  select(purchase_card, from: "auction_purchase_card")
+
+  find('.selectize-control.select.optional.multi').click
+  find('.selectize-dropdown-content', text: @skill.name).click
+
+  find('.selectize-control.select.required.single').click
+  find('.selectize-dropdown-content', text: @billable.to_s).click
+end
+
 When(/^I edit the new auction form$/) do
   @title = 'This is the form-edited title'
   fill_in("auction_title", with: @title)

--- a/spec/models/auction_spec.rb
+++ b/spec/models/auction_spec.rb
@@ -72,8 +72,7 @@ describe Auction do
       end
 
       it 'validates presence of c2_status' do
-        auction = create(:auction, published: :unpublished,
-                                   purchase_card: :default)
+        auction = create(:auction, :unpublished, purchase_card: :default)
 
         auction.published = :published
 


### PR DESCRIPTION
Scenario tests the case when Admin creates new auction
with 'other' purchase card and tries to publish it imidiately
